### PR TITLE
Some proofs, simplifications, formatting, and a build script.

### DIFF
--- a/Chapter1.thy
+++ b/Chapter1.thy
@@ -150,7 +150,7 @@ We now move on to prove some of the elementary claims in the text above, albeit 
 order. 
 \done\<close>
 
-  lemma symmetric_parallel: "l || m \<Longrightarrow> m || l" try
+  lemma symmetric_parallel: "l || m \<Longrightarrow> m || l"
     using parallel_def by auto
 (*
 proof -
@@ -178,9 +178,10 @@ proof -
       using parallel_def by auto
   qed
 *)
-
+  text \<open>\daniel\<close>
   lemma transitive_parallel: "\<lbrakk>l || m ;  m || n\<rbrakk> \<Longrightarrow> l || n"
     by (metis a2 parallel_def)
+  text \<open>\done\<close> 
 (*
   proof - 
     fix l :: "'line" and m :: "'line" and n :: "'line"
@@ -197,6 +198,9 @@ proof -
     qed
   qed
 *)
+
+lemma equivp_parallel: "equivp parallel"
+  by (metis (mono_tags) affine_plane_data.parallel_def equivpI reflp_def symp_def transitive_parallel transpI)
 end
 
 text  \<open>\spike To help Isabelle along, we insert a tiny theorem giving a different 
@@ -250,7 +254,7 @@ This is the smallest affine plane. [NB: We'll return to this final claim present
     using a1 by auto
 
 
-text \<open>\leavevmode \daniel
+text \<open>\daniel
 We can also prove some basic theorems about affine planes not in Hartshorne. \done\<close>
   (* Examples of some easy theorems about affine planes, not mentioned in Hartshorne *)
   (* Every point lies on some line *)
@@ -262,7 +266,7 @@ We can also prove some basic theorems about affine planes not in Hartshorne. \do
     using a1 a2 a3 parallel_def collinear_def by metis
 
 
-text \<open>\leavevmode \daniel\<close>
+text \<open>\daniel\<close>
 
 lemma (in affine_plane) contained_points: "\<forall> l.  \<exists> S T.  S\<noteq>T \<and> meets S l \<and> meets T l"
   proof -

--- a/Chapter1.thy
+++ b/Chapter1.thy
@@ -178,10 +178,10 @@ proof -
       using parallel_def by auto
   qed
 *)
-  text \<open>\daniel\<close>
+
   lemma transitive_parallel: "\<lbrakk>l || m ;  m || n\<rbrakk> \<Longrightarrow> l || n"
     by (metis a2 parallel_def)
-  text \<open>\done\<close> 
+
 (*
   proof - 
     fix l :: "'line" and m :: "'line" and n :: "'line"
@@ -198,10 +198,11 @@ proof -
     qed
   qed
 *)
-
+  text \<open>\daniel\<close>
 lemma equivp_parallel: "equivp parallel"
   by (metis (mono_tags) affine_plane_data.parallel_def equivpI reflp_def symp_def transitive_parallel transpI)
 end
+  text \<open>\done\<close> 
 
 text  \<open>\spike To help Isabelle along, we insert a tiny theorem giving a different 
 characterization of parallelism \done\<close>

--- a/Chapter1.thy
+++ b/Chapter1.thy
@@ -150,7 +150,7 @@ We now move on to prove some of the elementary claims in the text above, albeit 
 order. 
 \done\<close>
 
-  lemma symmetric_parallel: "l || m \<Longrightarrow> m || l"
+  lemma symmetric_parallel: "l || m \<Longrightarrow> m || l" try
   proof -
     fix l :: "'line" and m :: "'line"
     assume one_direction: "l || m"
@@ -236,14 +236,54 @@ This is the smallest affine plane. [NB: We'll return to this final claim present
 \end{hartshorne}
 \<close>
 
+  (* Two lines meet in at most one point *)
+  lemma (in affine_plane) prop1P2: "\<lbrakk>l \<noteq> m; meets P l; meets P m; meets Q l; meets Q m\<rbrakk> \<Longrightarrow> P = Q"
+    using a1 by auto
+
+
+text \<open>\leavevmode \daniel
+We can also prove some basic theorems about affine planes not in Hartshorne. \done\<close>
+  (* Examples of some easy theorems about affine planes, not mentioned in Hartshorne *)
+  (* Every point lies on some line *)
+  lemma (in affine_plane) containing_line: "\<forall>S. \<exists>l. meets S l"
+    using a2 by blast
+
+  (* Every line contains at least one point *)
+  lemma (in affine_plane) contained_point: "\<forall>l. \<exists>S. meets S l"
+    using a1 a2 a3 parallel_def collinear_def by metis
+
+
+text \<open>\leavevmode \daniel\<close>
+
+lemma (in affine_plane) contained_points: "\<forall> l.  \<exists> S T.  S\<noteq>T \<and> meets S l \<and> meets T l"
+  proof -
+    fix l::"'line"
+    obtain S where S:"meets S l" using contained_point
+      by auto
+    obtain P Q R where PQR: "P \<noteq> Q \<and> P \<noteq> R \<and> Q \<noteq> R \<and> \<not> collinear P Q R"
+      using a3 by blast
+    obtain A B where AB: "A \<noteq> B \<and> A \<noteq> S \<and> B \<noteq> S \<and> \<not> collinear A B S"
+      by (smt PQR collinear_def prop1P2)
+    obtain C where C: "(C=A \<or> C=B) \<and> \<not> meets C l"
+      using AB S collinear_def by blast
+    obtain m where m: "meets C m \<and> meets S m"
+      by (metis AB a1)
+    obtain D where D: "(D = A \<or> D = B) \<and> D \<noteq> C"
+      using AB by blast
+    thus ?thesis
+      by (smt AB C D S a2 affine_plane_data.collinear_def m parallel_def symmetric_parallel transitive_parallel)
+  qed
+
+  text \<open>\done\<close>
+
   section  \<open> The real affine plane\<close>
   text \<open> Hartshorne mentioned, just after the definition of an affine plane and some notational 
 notes, that the ordinary affine plane is an example of an affine plane. We should prove 
 that it's actually an affine plane. It's pretty clear how to represent points --- pairs of real 
 numbers --- but what about lines? A line is the set of points satisfying an equation of 
 the form Ax + By + C = 0, with not both of A and B being zero. The problem is that there's 
-no datatype for "pair of real numbers, at least one of which is nonzero". We'll have 
-to hack this by breaking lines into "ordinary" and "vertical", alas.   \<close>
+no datatype for ``pair of real numbers, at least one of which is nonzero''. We'll have 
+to hack this by breaking lines into ``ordinary'' and ``vertical'', alas.   \<close>
 
   datatype a2pt = A2Point "real" "real"
 
@@ -262,10 +302,10 @@ as a forall rather than exists. I think this might make things easier.\<close>
   text\<open>Now some small lemmas, basically establishing the three axioms \<close>
   text\<open> I'm going to venture into a new style of writing theorems and proofs, one that's
 particularly applicable when you're showing something exists by constructing it. Here is 
-an example in the case of real numbers: if r < s, then there's a real number strictly between
-them. We could write this as "r < s shows that there is a t . ((r < t) and (t < s))" (although it turns out we'd have
-to start with "(r::real) < s ..." to tell Isar not to assume that r is a natural number -- after all, 
-this is one of those cases where type-inference has no idea whether "<" means less-than on the reals,
+an example in the case of real numbers: if $r < s$, then there's a real number strictly between
+them. We could write this as ``$r < s$ shows that there is a $t$ . ($(r < t)$ and $(t < s)$)'' (although it turns out we'd have
+to start with ``\texttt{(r::real) < s ...}'' to tell Isar not to assume that r is a natural number -- after all, 
+this is one of those cases where type-inference has no idea whether ``<'' means less-than on the reals,
 or the integers, or the natural numbers, or ...)
 
 Anyhow, in this new style, we would write the theorem like this:
@@ -632,28 +672,6 @@ theorem A2_affine: "affine_plane(a2meets)"
   using A2_a3 by auto
 
 text\<open>\done \done\<close>
-  (* Examples of some easy theorems about affine planes, not mentioned in Hartshorne *)
-  (* Every point lies on some line *)
-  lemma (in affine_plane) containing_line: " \<forall>S. \<exists>l. meets S l"
-    sorry
-
-  (* Every line contains at least one point *)
-  lemma (in affine_plane) contained_point: "\<forall>l. \<exists>S. meets S l"
-    sorry
-
-  (* Two lines meet in at most one point *)
-  lemma (in affine_plane) prop1P2: "\<lbrakk>l \<noteq> m; meets P l; meets P m; meets Q l; meets Q m\<rbrakk> \<Longrightarrow> P = Q"
-    sorry
-
-(* Some HW Problems to give you practice with Isabelle:
-Try to state and prove these:
-1. Every line contains at least two points (this is stated for you below, but
-with "sorry" as a "proof". 
-2. Every line contains at least three points [false!]
-*)
-
-lemma (in affine_plane) contained_points: "\<forall> l.  \<exists> S T.  S\<noteq>T \<and> meets S l \<and> meets T l"
-  sorry
 
   text \<open>
  We now try to prove that every affine plane contains at least four points. Sledgehammer 

--- a/Chapter1.thy
+++ b/Chapter1.thy
@@ -151,7 +151,9 @@ order.
 \done\<close>
 
   lemma symmetric_parallel: "l || m \<Longrightarrow> m || l" try
-  proof -
+    using parallel_def by auto
+(*
+proof -
     fix l :: "'line" and m :: "'line"
     assume one_direction: "l || m"
     show "m || l"
@@ -164,16 +166,22 @@ order.
         by (simp add: parallel_def)
     qed
   qed
+*)
 
   lemma reflexive_parallel: "l || l"
+    using parallel_def by blast
+(*
   proof - 
     have "l = l" 
       by auto
     thus "l || l"
       using parallel_def by auto
   qed
+*)
 
   lemma transitive_parallel: "\<lbrakk>l || m ;  m || n\<rbrakk> \<Longrightarrow> l || n"
+    by (metis a2 parallel_def)
+(*
   proof - 
     fix l :: "'line" and m :: "'line" and n :: "'line"
     assume lm: "l || m"
@@ -188,6 +196,7 @@ order.
         by (metis a2 lm parallel_def)
     qed
   qed
+*)
 end
 
 text  \<open>\spike To help Isabelle along, we insert a tiny theorem giving a different 
@@ -305,7 +314,7 @@ particularly applicable when you're showing something exists by constructing it.
 an example in the case of real numbers: if $r < s$, then there's a real number strictly between
 them. We could write this as ``$r < s$ shows that there is a $t$ . ($(r < t)$ and $(t < s)$)'' (although it turns out we'd have
 to start with ``\texttt{(r::real) < s ...}'' to tell Isar not to assume that r is a natural number -- after all, 
-this is one of those cases where type-inference has no idea whether ``<'' means less-than on the reals,
+this is one of those cases where type-inference has no idea whether ``$<$'' means less-than on the reals,
 or the integers, or the natural numbers, or ...)
 
 Anyhow, in this new style, we would write the theorem like this:

--- a/build
+++ b/build
@@ -1,0 +1,2 @@
+#!/bin/sh
+isabelle build -v -d . -o browser_info -o document=pdf geometry

--- a/document/book-defs.tex
+++ b/document/book-defs.tex
@@ -24,7 +24,7 @@
 \newcommand{\david}  {{\\ \color{brown}\rule{1cm}{0.2cm} }}
 \newcommand{\ken}    {{\\ \color{green}\rule{1cm}{0.2cm} }}
 \newcommand{\jackson}{{\\ \color{lime}\rule{1cm}{0.2cm} }}
-\newcommand{\daniel} {{\\ \color{magenta}\rule{1cm}{0.2cm} }}
+\newcommand{\daniel} {{~\newline \color{magenta}\rule{1cm}{0.2cm} }}
 \newcommand{\james}  {{\\ \color{violet}\rule{1cm}{0.2cm} }}
 \newcommand{\justin} {{\\ \color{red}\rule{1cm}{0.2cm} }}
 \newcommand{\petar}  {{\\ \color{LightSalmon}\rule{1cm}{0.2cm} }}

--- a/document/book-defs.tex
+++ b/document/book-defs.tex
@@ -21,17 +21,17 @@
 
 
 \newcommand{\spike}  {{~\newline \color{red}\rule{1cm}{0.2cm} }}
-\newcommand{\david}  {{\\ \color{brown}\rule{1cm}{0.2cm} }}
-\newcommand{\ken}    {{\\ \color{green}\rule{1cm}{0.2cm} }}
-\newcommand{\jackson}{{\\ \color{lime}\rule{1cm}{0.2cm} }}
+\newcommand{\david}  {{~\\ \color{brown}\rule{1cm}{0.2cm} }}
+\newcommand{\ken}    {{~\\ \color{green}\rule{1cm}{0.2cm} }}
+\newcommand{\jackson}{{~\\ \color{lime}\rule{1cm}{0.2cm} }}
 \newcommand{\daniel} {{~\newline \color{magenta}\rule{1cm}{0.2cm} }}
-\newcommand{\james}  {{\\ \color{violet}\rule{1cm}{0.2cm} }}
-\newcommand{\justin} {{\\ \color{red}\rule{1cm}{0.2cm} }}
-\newcommand{\petar}  {{\\ \color{LightSalmon}\rule{1cm}{0.2cm} }}
-\newcommand{\seiji}  {{\\ \color{DeepSkyBlue}\rule{1cm}{0.2cm} }}
-\newcommand{\caleb}  {{\\ \color{BlueViolet}\rule{1cm}{0.2cm} }}
-\newcommand{\homer}  {{\\ \color{orange}\rule{1cm}{0.2cm} }}
-\newcommand{\siqi}   {{\\ \color{cyan}\rule{1cm}{0.2cm} }}
-\newcommand{\haoze}  {{\\ \color{blue}\rule{1cm}{0.2cm} }}
+\newcommand{\james}  {{~\\ \color{violet}\rule{1cm}{0.2cm} }}
+\newcommand{\justin} {{~\\ \color{red}\rule{1cm}{0.2cm} }}
+\newcommand{\petar}  {{~\\ \color{LightSalmon}\rule{1cm}{0.2cm} }}
+\newcommand{\seiji}  {{~\\ \color{DeepSkyBlue}\rule{1cm}{0.2cm} }}
+\newcommand{\caleb}  {{~\\ \color{BlueViolet}\rule{1cm}{0.2cm} }}
+\newcommand{\homer}  {{~\\ \color{orange}\rule{1cm}{0.2cm} }}
+\newcommand{\siqi}   {{~\\ \color{cyan}\rule{1cm}{0.2cm} }}
+\newcommand{\haoze}  {{~\\ \color{blue}\rule{1cm}{0.2cm} }}
 \newcommand{\done}   {{~\newline \color{black}\rule{1cm}{0.2cm} }}
 


### PR DESCRIPTION
I've added the proofs for some of the simple theorems for affine plane. I also drastically shortened the proofs for the properties of parallel and added the result that parallel is an equivalence relation (equivp).

For formatting I fixed some quotation marks (note that in Latex one needs ``...'' for correct quotes and fixed the appearance of "<" (need to use \textless or math mode). Also the macros for each person complained in certain contexts (when starting a line) so I added a fix for that.

Finally, for convenience I added a build script.