### PR TITLE
More work on duality

### DIFF
--- a/Chapter4.thy
+++ b/Chapter4.thy
@@ -110,9 +110,23 @@ proof -
   thus ?thesis unfolding dmeets_def by auto
 qed
 
-theorem "projective_plane dmeets"
+text\<open>\daniel This allows us an easy way to prove the duals of theorems
+in a projective plane\<close>
+
+theorem dualthm:"projective_plane dmeets"
   unfolding projective_plane_def
-  using dmeets_p1b dmeets_p2 dmeets_p3 local.pmeets_p4 by blast 
+  using dmeets_p1b dmeets_p2 dmeets_p3 local.pmeets_p4 by blast
+
+
+interpretation dual:projective_plane dmeets using dualthm by simp
+
+lemma linesOffPoints: (* dual of pointOffLines *)
+  fixes P::"'point" and Q::"'point"
+  assumes "P \<noteq> Q"
+  shows "\<exists>l::'line. (\<not> meets P l) \<and> (\<not> meets Q l)"
+  using pointOffLines dual.pointOffLines assms dmeets_def by blast
+
+text\<open>\done\<close>
 end
 
 

--- a/Chapter4.thy
+++ b/Chapter4.thy
@@ -113,18 +113,15 @@ qed
 text\<open>\daniel This allows us an easy way to prove the duals of theorems
 in a projective plane\<close>
 
-theorem dualthm:"projective_plane dmeets"
+interpretation dual:projective_plane dmeets
   unfolding projective_plane_def
   using dmeets_p1b dmeets_p2 dmeets_p3 local.pmeets_p4 by blast
-
-
-interpretation dual:projective_plane dmeets using dualthm by simp
 
 lemma linesOffPoints: (* dual of pointOffLines *)
   fixes P::"'point" and Q::"'point"
   assumes "P \<noteq> Q"
   shows "\<exists>l::'line. (\<not> meets P l) \<and> (\<not> meets Q l)"
-  using pointOffLines dual.pointOffLines assms dmeets_def by blast
+  using dual.pointOffLines assms dmeets_def by blast
 
 text\<open>\done\<close>
 end

--- a/Chapter4.thy
+++ b/Chapter4.thy
@@ -97,8 +97,6 @@ lemma "pmeets_p4": "\<exists>P Q R. P \<noteq> Q \<and> P \<noteq> R \<and> Q \<
 proof - 
   obtain A where A:"\<not> meets l A" using dmeets_def dmeets_p3
     by (smt projective_plane_data.collinear_def)
-  then have "\<not>dmeets A l"
-    by (simp add: dmeets_def)
   obtain m n k where mnk:"meets m A \<and> meets n A \<and> meets k A \<and> m \<noteq> n \<and> n \<noteq> k \<and> m \<noteq>k"
     using p4 by blast
   obtain P where P: "meets l P \<and> meets m P"
@@ -113,7 +111,8 @@ proof -
 qed
 
 theorem "projective_plane dmeets"
-  sorry
+  unfolding projective_plane_def
+  using dmeets_p1b dmeets_p2 dmeets_p3 local.pmeets_p4 by blast 
 end
 
 


### PR DESCRIPTION
Removed unecessary line in dmeets_p4 and added proof the dmeets is a projective plane. We can use `interpretation `to easily prove the duals of theorems in the projective plane. For example, I prove the dual of `PointOffLine`.